### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 [![smithery badge](https://smithery.ai/badge/@liveblocks/liveblocks-mcp-server)](https://smithery.ai/server/@liveblocks/liveblocks-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/@liveblocks/liveblocks-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@liveblocks/liveblocks-mcp-server/badge" alt="Liveblocks MCP server" />
+</a>
+
 This MCP server allows AI to use a number of functions from our [REST API](https://liveblocks.io/docs/api-reference/rest-api-endpoints). For example, it can create, modify, and delete different aspects of Liveblocks such as rooms, threads, comments, notifications, and more. It also has read access to Storage and Yjs. [Learn more in our docs](https://liveblocks.io/docs/tools/mcp-server).
 
 ## Automatic setup


### PR DESCRIPTION
This PR adds a badge for the [Liveblocks](https://glama.ai/mcp/servers/@liveblocks/liveblocks-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@liveblocks/liveblocks-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@liveblocks/liveblocks-mcp-server/badge" alt="Liveblocks MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.