### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,8 @@ sk_dev_Ns35f5G...
 ```
 
 </details>
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/liveblocks-liveblocks-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/liveblocks-liveblocks-mcp-server)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an external hosted deployment link; no code or behavior changes.
> 
> **Overview**
> Adds a new **Hosted deployment** section to `README.md` that points readers to a Fronteir AI URL for a hosted version of the MCP server.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d4a82c9cd746bd7a78f37044d109afbc7800bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->